### PR TITLE
Change int to double for Available and Current in Account Entities

### DIFF
--- a/PlaidSharp/Entities/Account.cs
+++ b/PlaidSharp/Entities/Account.cs
@@ -19,9 +19,9 @@
 
     public class Balances
     {
-        public int? Available { get; set; }
+        public double? Available { get; set; }
 
-        public int? Current { get; set; }
+        public double? Current { get; set; }
 
         public object Limit { get; set; }
 


### PR DESCRIPTION
Using the demo app in the sand box I would get a error from Current Account Balance being 35.17.
Changing the int to a double fixed this bug. I propose changing it on both Available and Current.